### PR TITLE
Fix compilation error of readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ method:
 use semver::Version;
 
 assert!(Version::parse("1.2.3") == Ok(Version {
-   major: 1u,
-   minor: 2u,
-   patch: 3u,
+   major: 1,
+   minor: 2,
+   patch: 3,
    pre: vec!(),
    build: vec!(),
 }));


### PR DESCRIPTION
Mismatched types were cause of the following error when try to compile the example code:

```
error: mismatched types: expected `u64`, found `usize` (expected u64, found usize)
```

The issue pretty much resembles rust-lang/rust#20967 in rust-lang/rust#20895.