### PR TITLE
Introduce the ability to increment mutable Versions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,20 @@
 //! assert!(Version::parse("1.2.3-alpha2") >  Version::parse("1.2.0"));
 //! ```
 //!
+//! If you explicitly need to modify a Version, SemVer also allows you to 
+//! increment the major, minor, and patch numbers in accordance with the spec.
+//! 
+//! Please note that in order to do this, you must use a mutable Version:
+//!
+//! ```{rust}
+//! use semver::Version;
+//!
+//! let mut feature_release = Version::parse("1.4.6").unwrap();
+//! feature_release.increment_minor();
+//!
+//! assert_eq!(feature_release, Version::parse("1.5.0").unwrap());
+//! ```
+//!
 //! ## Requirements
 //!
 //! The `semver` crate also provides the ability to compare requirements, which

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,10 +71,34 @@
 //! ```{rust}
 //! use semver::Version;
 //!
+//! let mut bugfix_release = Version::parse("1.0.0").unwrap();
+//! bugfix_release.increment_patch();
+//!
+//! assert_eq!(bugfix_release, Version::parse("1.0.1").unwrap());
+//! ```
+//!
+//! When incrementing the minor version number, the patch number resets to zero 
+//! (in accordance with section 7 of the spec)
+//!
+//! ```{rust}
+//! use semver::Version;
+//!
 //! let mut feature_release = Version::parse("1.4.6").unwrap();
 //! feature_release.increment_minor();
 //!
 //! assert_eq!(feature_release, Version::parse("1.5.0").unwrap());
+//! ```
+//!
+//! Similarly, when incrementing the major version number, the patch and minor
+//! numbers reset to zero (in accordance with section 8 of the spec)
+//!
+//! ```{rust}
+//! use semver::Version;
+//!
+//! let mut chrome_release = Version::parse("41.5.5377").unwrap();
+//! chrome_release.increment_major();
+//!
+//! assert_eq!(chrome_release, Version::parse("42.0.0").unwrap());
 //! ```
 //!
 //! ## Requirements

--- a/src/version.rs
+++ b/src/version.rs
@@ -88,6 +88,28 @@ impl Version {
             None => Err(GenericFailure)
         }
     }
+
+    ///Increments the patch number for this Version (Must be mutable)
+    pub fn increment_patch(&mut self) {
+        self.patch += 1;
+    }
+
+    ///Increments the minor version number for this Version (Must be mutable)
+    ///
+    ///As instructed by section 7 of the spec, the patch number is reset to 0.
+    pub fn increment_minor(&mut self) {
+        self.minor += 1;
+        self.patch = 0;
+    }
+
+    ///Increments the major version number for this Version (Must be mutable)
+    ///
+    ///As instructed by section 8 of the spec, the minor and patch numbers are reset to 0
+    pub fn increment_major(&mut self) {
+        self.major += 1;
+        self.minor = 0;
+        self.patch = 0;
+    }
 }
 
 
@@ -389,6 +411,27 @@ mod test {
             build: vec![AlphaNumeric("0851523".to_string())],
         }));
 
+    }
+
+    #[test]
+    fn test_increment_patch() {
+        let mut buggy_release = Version::parse("0.1.0").unwrap();
+        buggy_release.increment_patch();
+        assert_eq!(buggy_release, Version::parse("0.1.1").unwrap());
+    }
+
+    #[test]
+    fn test_increment_minor() {
+        let mut feature_release = Version::parse("1.4.6").unwrap();
+        feature_release.increment_minor();
+        assert_eq!(feature_release, Version::parse("1.5.0").unwrap());
+    }
+
+    #[test]
+    fn test_increment_major() {
+        let mut chrome_release = Version::parse("46.1.246773").unwrap();
+        chrome_release.increment_major();
+        assert_eq!(chrome_release, Version::parse("47.0.0").unwrap());
     }
 
     #[test]

--- a/src/version.rs
+++ b/src/version.rs
@@ -89,9 +89,15 @@ impl Version {
         }
     }
 
+    ///Clears the build metadata
+    fn clear_metadata(&mut self) {
+        self.build = vec!()
+    }
+
     ///Increments the patch number for this Version (Must be mutable)
     pub fn increment_patch(&mut self) {
         self.patch += 1;
+        self.clear_metadata();
     }
 
     ///Increments the minor version number for this Version (Must be mutable)
@@ -100,6 +106,7 @@ impl Version {
     pub fn increment_minor(&mut self) {
         self.minor += 1;
         self.patch = 0;
+        self.clear_metadata();
     }
 
     ///Increments the major version number for this Version (Must be mutable)
@@ -109,6 +116,7 @@ impl Version {
         self.major += 1;
         self.minor = 0;
         self.patch = 0;
+        self.clear_metadata();
     }
 }
 
@@ -432,6 +440,41 @@ mod test {
         let mut chrome_release = Version::parse("46.1.246773").unwrap();
         chrome_release.increment_major();
         assert_eq!(chrome_release, Version::parse("47.0.0").unwrap());
+    }
+
+    #[test]
+    fn test_increment_keep_prerelease() {
+        let mut release = Version::parse("1.0.0-alpha").unwrap();
+        release.increment_patch();
+
+        assert_eq!(release, Version::parse("1.0.1-alpha").unwrap());
+
+        release.increment_minor();
+
+        assert_eq!(release, Version::parse("1.1.0-alpha").unwrap());
+
+        release.increment_major();
+
+        assert_eq!(release, Version::parse("2.0.0-alpha").unwrap());
+    }
+
+
+    #[test]
+    fn test_increment_clear_metadata() {
+        let mut release = Version::parse("1.0.0+4442").unwrap();
+        release.increment_patch();
+
+        assert_eq!(release, Version::parse("1.0.1").unwrap());
+        release = Version::parse("1.0.1+hello").unwrap();
+
+        release.increment_minor();
+
+        assert_eq!(release, Version::parse("1.1.0").unwrap());
+        release = Version::parse("1.1.3747+hello").unwrap();
+
+        release.increment_major();
+
+        assert_eq!(release, Version::parse("2.0.0").unwrap());
     }
 
     #[test]


### PR DESCRIPTION
I had a quick look through the spec, and could not find any information on if build metadata and pre-release information should be wiped when incrementing versions. Because of that, I have left them untouched; I'll have another look when I get home from work, and fix it if I am in error.

If you don't want to support mutable Versions, let me know, and I'll re-implement this in a suitable manner. 

Thanks in advance :)