### PR TITLE
Make Travis.CI use four jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ rust:
   - nightly
 sudo: false
 script:
-  - cargo build --verbose
-  - cargo test --verbose
-  - cargo doc
+  - cargo build --verbose -j 2
+  - cargo test --verbose -j 2
+  - cargo doc -j 2
 after_success: |
   [ $TRAVIS_BRANCH = master ] &&
   [ $TRAVIS_PULL_REQUEST = false ] &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ rust:
   - nightly
 sudo: false
 script:
-  - cargo build --verbose -j 2
-  - cargo test --verbose -j 2
-  - cargo doc -j 2
+  - cargo build --verbose -j 4
+  - cargo test --verbose -j 4
+  - cargo doc -j 4
 after_success: |
   [ $TRAVIS_BRANCH = master ] &&
   [ $TRAVIS_PULL_REQUEST = false ] &&


### PR DESCRIPTION
Travis.CI uses 1.5 virtual cores, so theoretically, using ~~two~~ four "jobs" when compiling/testing/generating documentation will cause a slight performance increase. However, using any more than ~~two~~ four jobs will probably not cause any difference in performance.

(I originally read two jobs, but the example in the link below used four jobs - Sorry)

Found on http://docs.travis-ci.com/user/speeding-up-the-build/#Parallelizing-your-build-on-one-VM
