### PR TITLE
Implement Error for ParseError

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "semver"
-version = "0.1.19"
+version = "0.1.20"
 authors = ["The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rust-lang/semver"

--- a/src/version.rs
+++ b/src/version.rs
@@ -13,6 +13,7 @@
 
 use std::ascii::AsciiExt;
 use std::cmp::{self, Ordering};
+use std::error::Error;
 use std::fmt;
 use std::hash;
 
@@ -195,17 +196,29 @@ impl cmp::Ord for Version {
     }
 }
 
+impl Error for ParseError {
+    fn description(&self) -> &str {
+        match *self {
+            ParseError::NonAsciiIdentifier
+                => "identifiers can only contain ascii characters",
+            ParseError::GenericFailure
+                | ParseError::IncorrectParse(..)
+                => "failed to parse semver from string",
+        }
+    }
+}
+
 impl fmt::Display for ParseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             ParseError::NonAsciiIdentifier => {
-                write!(f, "identifiers can only contain ascii characters")
+                write!(f, "{}", self.description())
             }
             ParseError::GenericFailure => {
-                write!(f, "failed to parse semver from string")
+                write!(f, "{}", self.description())
             }
             ParseError::IncorrectParse(ref a, ref b) => {
-                write!(f, "semver `{}` was not correctly parsed from {:?}", a, b)
+                write!(f, "{}: {} could not be parsed from {:?}", self.description(), a, b)
             }
         }
     }


### PR DESCRIPTION
Had an issue in which I couldn't up-cast semver's `ParseError` to `Box<Error>`. Didn't see PR #41 when I wrote this (oops!). Unlike the other PR, this patch doesn't restructure `ParseError` at all.